### PR TITLE
fix for magicgui 0.4.0

### DIFF
--- a/stardist_napari/_dock_widget.py
+++ b/stardist_napari/_dock_widget.py
@@ -23,7 +23,7 @@ import numpy as np
 from magicgui import magicgui
 from magicgui import widgets as mw
 from magicgui.application import use_app
-from magicgui.events import Event, Signal
+from psygnal import Signal
 from napari.qt.threading import thread_worker
 from napari.utils.colormaps import label_colormap
 from qtpy.QtWidgets import QSizePolicy


### PR DESCRIPTION
this should be all that's necessary to fix for magicgui 0.4.0

but, if you think it's the better fix, I would also consider releasing a new magicgui 0.4.1 with a pass-through module `magicgui.events` that just exports `psygnal.Signal`.  Thoughts?